### PR TITLE
Added isOrdered option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,17 @@
 Change log of triplclust
 =========================
 
+Version 1.5 from 2024-01-15
+---------------------------
+
+ - added option -isOrdered 
+ 
+ - implemented searching trajectories in an ordered cloud 
+ (thanks to Juliane Arning)
+
+Version 1.4 from ?
+---------------------------
+
  - step 3) of the pruning method described at the end of section 2.4
    in the IPOL article was missing and has now been added
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ is the space character, but a different character can be specified with the
 command line option "-delim <char>". Lines starting with a hash (#) are
 ignored. 
 
+With the -isOrdered option, the input file is treated as ordered, i.e. the 
+points have to be in chronological order. 
+
 Unless the option "-oprefix <prefix>" is given, the output is printed to
 stdout. The default output format is a comma separated file with two header
 lines (starting with #) and one point per line followed by the cluster label.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,8 @@ const char *usage =
     "\t               (can be numeric, multiple of dNN or 'none')\n"
     "\t-link <method> linkage method for clustering [single]\n"
     "\t               (can be 'single', 'complete', 'average')\n"
+    "\t-isOrdered     interpret infile as ordered\n"
+    "\t               (i.e. file has to be in chronological order)\n"
     "\t-oprefix <prefix>\n"
     "\t               write result not to stdout, but to <prefix>.csv\n"
     "\t               and (if -gnuplot is set) to <prefix>.gnuplot\n"
@@ -61,6 +63,7 @@ int main(int argc, char **argv) {
   const char *infile_name = opt_params.get_ifname();
   const char *outfile_prefix = opt_params.get_ofprefix();
   int opt_verbose = opt_params.get_verbosity();
+  bool isOrdered = opt_params.get_isOrdered();
 
   // plausibility checks
   if (!infile_name) {
@@ -70,6 +73,8 @@ int main(int argc, char **argv) {
 
   // load data
   PointCloud cloud_xyz;
+  cloud_xyz.setOrdered(isOrdered);
+  
   try {
     load_csv_file(infile_name, cloud_xyz, opt_params.get_delimiter(),
                   opt_params.get_skip());

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -53,6 +53,7 @@ Opt::Opt() {
 int Opt::parse_args(int argc, char** argv) {
   // parse command line
   std::pair<double, bool> tmp;
+  this->isOrdered = false;
   try {
     for (int i = 1; i < argc; i++) {
       if (0 == strcmp(argv[i], "-v")) {
@@ -82,6 +83,8 @@ int Opt::parse_args(int argc, char** argv) {
         } else {
           return 1;
         }
+      } else if (0 == strcmp(argv[i], "-isOrdered")) {      //!
+        this->isOrdered = true;                             //!
       } else if (0 == strcmp(argv[i], "-n")) {
         ++i;
         if (i < argc) {
@@ -260,3 +263,4 @@ bool Opt::is_dmax() { return this->isdmax; }
 double Opt::get_dmax() { return this->dmax; }
 Linkage Opt::get_linkage() { return this->link; }
 size_t Opt::get_m() { return this->m; }
+bool Opt::get_isOrdered() {return this->isOrdered;}    //!

--- a/src/option.h
+++ b/src/option.h
@@ -48,6 +48,7 @@ class Opt {
   double dmax;
   bool isdmax;    // dmax != none
   bool dmax_dnn;  // use dnn for dmax
+  bool isOrdered=false;                         //!
   // linkage method for clustering
   Linkage link;
 
@@ -80,6 +81,7 @@ class Opt {
   double get_t();
   bool is_dmax();
   double get_dmax();
+  bool get_isOrdered();   //!
   Linkage get_linkage();
   size_t get_m();
 };

--- a/src/pointcloud.cpp
+++ b/src/pointcloud.cpp
@@ -53,6 +53,14 @@ Point::Point(double x, double y, double z,
   this->cluster_ids = cluster_ids;
 }
 
+Point::Point(double x, double y, double z, size_t index) {         //!
+  this->x = x;                                                     //!
+  this->y = y;                                                     //!
+  this->z = z;                                                     //!
+  this->index = index;                                             //!
+}
+
+
 // representation of 3D point as std::vector.
 std::vector<double> Point::as_vector() const {
   std::vector<double> point(3);
@@ -126,6 +134,12 @@ void PointCloud::set2d(bool is2d) { this->points2d = is2d; }
 
 bool PointCloud::is2d() const { return this->points2d; }
 
+
+void PointCloud::setOrdered(bool isOrdered) {this->ordered=isOrdered;} // !
+ 
+bool PointCloud::isOrdered() const { return this->ordered; } // !
+
+
 // Split string *input* into substrings by *delimiter*. The result is
 // returned in *result*
 void split(const std::string &input, std::vector<std::string> &result,
@@ -152,6 +166,7 @@ void load_csv_file(const char *fname, PointCloud &cloud, const char delimiter,
   std::string line;
   std::vector<std::string> items;
   size_t count = 0, count2d = 0, skiped = 0, countpoints = 0;
+  size_t countOrdered = 0; //!
   if (infile.fail()) throw std::exception();
   for (size_t i = 0; i < skip; ++i) {
     // skip the header
@@ -192,6 +207,7 @@ void load_csv_file(const char *fname, PointCloud &cloud, const char delimiter,
       point.y = stod(items[1].c_str());
       column++;
       point.z = stod(items[2].c_str());
+      point.index = countpoints-1;            //!
       cloud.push_back(point);
     } catch (const std::invalid_argument &e) {
       std::ostringstream oss;
@@ -199,6 +215,7 @@ void load_csv_file(const char *fname, PointCloud &cloud, const char delimiter,
           << e.what();
       throw std::invalid_argument(oss.str());
     }
+
     items.clear();
   }
 
@@ -263,6 +280,8 @@ void smoothen_cloud(const PointCloud &cloud, PointCloud &result_cloud,
     new_point.z =
         std::accumulate(z_list.begin(), z_list.end(), 0.0) / result_size;
 
+    new_point.index = point.index;               //!
     result_cloud.push_back(new_point);
   }
+  result_cloud.setOrdered(cloud.isOrdered());    //!
 }

--- a/src/pointcloud.h
+++ b/src/pointcloud.h
@@ -23,12 +23,14 @@ class Point {
   double y;
   double z;
   std::set<size_t> cluster_ids;
+  size_t index;                      //!
 
   Point(){};
   Point(const std::vector<double>& point);
   Point(const std::vector<double>& point, const std::set<size_t>& cluster_ids);
   Point(double x, double y, double z);
   Point(double x, double y, double z, const std::set<size_t>& cluster_ids);
+  Point(double x, double y, double z, size_t index); //!
 
   // representation of 3D point as std::vector
   std::vector<double> as_vector() const;
@@ -58,12 +60,16 @@ Point operator*(double c, Point x);
 class PointCloud : public std::vector<Point> {
  private:
   bool points2d;
+  bool ordered;   //!
 
  public:
   bool is2d() const;
   void set2d(bool is2d);
+  bool isOrdered() const;   //!
+  void setOrdered(bool isOrdered);  //!
   PointCloud();
 };
+
 
 // Load csv file.
 void load_csv_file(const char* fname, PointCloud& cloud, const char delimiter,


### PR DESCRIPTION
Using the option -isOrdered the input file is now treated as chronologically ordered. This changes which triplets are generated and may improve segmentation results. 